### PR TITLE
Ignore caps in comments (on their own lines only)

### DIFF
--- a/sqlup-mode.el
+++ b/sqlup-mode.el
@@ -54,13 +54,17 @@
   (insert ";"))
 
 (defun sqlup-maybe-capitalize-word-at-point ()
-  (let ((sqlup-current-word (thing-at-point 'symbol))
-        (sqlup-current-word-boundaries (bounds-of-thing-at-point 'symbol)))
-    (if (member (downcase sqlup-current-word) sqlup-keywords)
-        (progn
-          (delete-region (car sqlup-current-word-boundaries) (cdr sqlup-current-word-boundaries))
-          (insert (upcase sqlup-current-word))
-          ))))
+  (if (not (sqlup-is-commentp (thing-at-point 'line)))
+      (let ((sqlup-current-word (thing-at-point 'symbol))
+	    (sqlup-current-word-boundaries (bounds-of-thing-at-point 'symbol)))
+	(if (member (downcase sqlup-current-word) sqlup-keywords)
+	    (progn
+	      (delete-region (car sqlup-current-word-boundaries)
+			     (cdr sqlup-current-word-boundaries))
+	      (insert (upcase sqlup-current-word)))))))
+
+(defun sqlup-is-commentp (line)
+  (and (string-match "^\s*--.*$" line) t))
 
 ;;;###autoload
 (defun sqlup-capitalize-keywords-in-region ()


### PR DESCRIPTION
This ignores caps-ing in comments like: 

``` sql
-- Select username and permissions mask for user id 77.
SELECT u.username, u.permission_mask FROM SITE_USER AS U
       WHERE u.id = 77;
```

For now this doesn't handle other comment types (multi-line and normal `/* comment */` on a single line). Adding them would require modifying only the is-commentp predicate to detect this. 
