### PR TITLE
Use sql-mode's font-lock for checking

### DIFF
--- a/sqlup-mode.el
+++ b/sqlup-mode.el
@@ -56,11 +56,28 @@
 (defun sqlup-maybe-capitalize-word-at-point ()
   (let ((sqlup-current-word (thing-at-point 'symbol))
         (sqlup-current-word-boundaries (bounds-of-thing-at-point 'symbol)))
-    (if (member (downcase sqlup-current-word) sqlup-keywords)
+    (if (and sqlup-current-word (sqlup-is-keywordp (downcase sqlup-current-word)))
         (progn
-          (delete-region (car sqlup-current-word-boundaries) (cdr sqlup-current-word-boundaries))
-          (insert (upcase sqlup-current-word))
-          ))))
+          (delete-region (car sqlup-current-word-boundaries)
+			 (cdr sqlup-current-word-boundaries))
+          (insert (upcase sqlup-current-word))))))
+
+(defun sqlup-keywords-regexps ()
+  (if (not sqlup-local-keywords-regexps)
+      (setq-local sqlup-local-keywords-regexps
+		  (mapcar 'car sql-mode-font-lock-keywords)))
+  sqlup-local-keywords-regexps)
+
+(defun sqlup-is-keywordp (word)
+  (let* ((sqlup-keyword-found nil)
+	(sqlup-terms (sqlup-keywords-regexps))
+	(sqlup-term (car sqlup-terms)))
+    (while (and (not sqlup-keyword-found) sqlup-terms)
+      (setq sqlup-keyword-found (string-match sqlup-term word))
+      (setq sqlup-term (car sqlup-terms))
+      (setq sqlup-terms (cdr sqlup-terms)))
+    (and sqlup-keyword-found t)))
+
 
 ;;;###autoload
 (defun sqlup-capitalize-keywords-in-region ()
@@ -86,9 +103,12 @@
             (define-key map (kbd ";") 'sqlup-insert-semicolon-and-maybe-capitalize)
             map))
 
+(defvar sqlup-local-keywords-regexps nil
+  "Buffer local variable holding regexps from sql-mode to
+identify keywords.")
+
 (defvar sqlup-keywords
   '("absolute" "action" "add" "after" "all" "allocate" "alter" "and" "any" "are" "array" "as" "asc" "asensitive" "assertion" "asymmetric" "at" "atomic" "authorization" "avg" "before" "begin" "between" "bigint" "binary" "bit" "bitlength" "blob" "boolean" "both" "breadth" "by" "call" "called" "cascade" "cascaded" "case" "cast" "catalog" "char" "char_length" "character" "character_length" "check" "clob" "close" "coalesce" "collate" "collation" "column" "commit" "condition" "connect" "connection" "constraint" "constraints" "constructor" "contains" "continue" "convert" "corresponding" "count" "create" "cross" "cube" "current" "current_date" "current_default_transform_group" "current_path" "current_role" "current_time" "current_timestamp" "current_transform_group_for_type" "current_user" "cursor" "cycle" "data" "date" "day" "deallocate" "dec" "decimal" "declare" "default" "deferrable" "deferred" "delete" "depth" "deref" "desc" "describe" "descriptor" "deterministic" "diagnostics" "disconnect" "distinct" "do" "domain" "double" "drop" "dynamic" "each" "element" "else" "elseif" "end" "equals" "escape" "except" "exception" "exec" "execute" "exists" "exit" "external" "extract" "false" "fetch" "filter" "first" "float" "for" "foreign" "found" "free" "from" "full" "function" "general" "get" "global" "go" "goto" "grant" "group" "grouping" "handler" "having" "hold" "hour" "identity" "if" "immediate" "in" "indicator" "initially" "inner" "inout" "input" "insensitive" "insert" "int" "integer" "intersect" "interval" "into" "is" "isolation" "iterate" "join" "key" "language" "large" "last" "lateral" "leading" "leave" "left" "level" "like" "limit" "local" "localtime" "localtimestamp" "locator" "loop" "lower" "map" "match" "map" "member" "merge" "method" "min" "minute" "modifies" "module" "month" "multiset" "names" "national" "natural" "nchar" "nclob" "new" "next" "no" "none" "not" "null" "nullif" "numeric" "object" "octet_length" "of" "old" "on" "only" "open" "option" "or" "order" "ordinality" "out" "outer" "output" "over" "overlaps" "pad" "parameter" "partial" "partition" "path" "position" "precision" "prepare" "preserve" "primary" "prior" "privileges" "procedure" "public" "range" "read" "reads" "real" "recursive" "ref" "references" "referencing" "relative" "release" "repeat" "resignal" "restrict" "result" "return" "returns" "revoke" "right" "role" "rollback" "rollup" "routine" "row" "rows" "savepoint" "schema" "scope" "scroll" "search" "second" "section" "select" "sensitive" "session" "session_user" "set" "sets" "signal" "similar" "size" "smallint" "some" "space" "specific" "specifictype" "sql" "sqlcode" "sqlerror" "sqlexception" "sqlstate" "sqlwarning" "start" "state" "static" "submultiset" "substring" "sum" "symmetric" "system" "system_user" "table" "tablesample" "temporary" "then" "time" "timestamp" "timezone_hour" "timezone_minute" "to" "trailing" "transaction" "translate" "translation" "treat" "trigger" "trim" "true" "under" "undo" "union" "unique" "unknown" "unnest" "until" "update" "upper" "usage" "user" "using" "value" "values" "varchar" "varying" "view" "when" "whenever" "where" "while" "window" "with" "within" "without" "work" "write" "year" "zone")
-  "This is a list of SQL keywords from the SQL standard"
-  )
+  "This is a list of SQL keywords from the SQL standard")
 
 (provide 'sqlup-mode)


### PR DESCRIPTION
Note that this requires a sql-mode buffer. This change also keeps
`sqlup-keywords' for now as they're necessary for caps-ing a region.

This **won't** work for use in org-mode or other major mode outside of `sql-mode` itself and its "products". sql-mode does set sql-mode-font-lock to be the correct keywords depending on the flavor. If the correct product is not set and changed after loading sql-mode, sqlup-mode must also be reloaded as it caches the regexes from whatever product font-lock sql-mode has when sqlUP-ing the first time. 
