### PR TITLE
Invalidate `sqlup-local-keywords-regexps` after product changes

### DIFF
--- a/sqlup-mode.el
+++ b/sqlup-mode.el
@@ -160,4 +160,11 @@
   "Buffer local variable holding regexps from sql-mode to
 identify keywords.")
 
+;; Advice sql-set-product, to invalidate sqlup's keyword cache after changing
+;; the sql product. We need to advice sql-set-product since sql-mode does not
+;; provide any hook that runs after changing the product
+(defadvice sql-set-product (after sqlup-invalidate-sqlup-keyword-cache activate)
+  "Invalidate sqlup-keyword cache after sql-product changes"
+  (setq sqlup-local-keywords-regexps nil))
+
 (provide 'sqlup-mode)


### PR DESCRIPTION
This sets `sqlup-local-keywords-regexps` to `nil` after sql product is changed. Since sql-mode does not provide any hook that are run after changing the sql product, we need to advice `sql-set-product` to invalidate the cache. Old advice system (`defadvice`) is used instead of the new mechanism (`advice-add`) which available only in Emacs 24.4 and higher does would fail on old Emacs.

Fixes #33 