### PR TITLE
Upcase keywords in eval strings

### DIFF
--- a/sqlup-mode.el
+++ b/sqlup-mode.el
@@ -64,6 +64,9 @@ identify keywords.")
 
 (defvar in-execute-string nil)
 
+(defvar eval-keywords
+  '((postgres "EXECUTE")))
+
 ;;;###autoload
 (define-minor-mode sqlup-mode
   "Capitalizes SQL keywords for you."
@@ -117,10 +120,14 @@ identify keywords.")
         (delete-region (car symbol-boundaries)
                        (cdr symbol-boundaries))
 	(setq last-sql-keyword symbol)
-	(if (string-match "execute" last-sql-keyword)
-	    (setq in-execute-string t)) ;; the execute keyword triggers upcase for formatted SQL
-;;	(message "in execute string=%s" in-execute-string)
+	(if (sqlup-match-eval-keyword-p (or (and (boundp 'sql-product) sql-product) 'ansi) symbol)
+	    (setq in-execute-string t)) ;;  upcase formatted SQL in eval strings
         (insert (upcase symbol)))))
+
+(defun sqlup-match-eval-keyword-p(dialect keyword)
+  "Does KEYWORD announce an eval string in DIALECT?"
+  (some 'identity
+	(mapcar #'(lambda (kw) (string-equal kw keyword)) (assoc dialect eval-keywords))))
 
 (defun sqlup-capitalizable-p (point-location)
   (let ((old-buffer (current-buffer)))

--- a/sqlup-mode.el
+++ b/sqlup-mode.el
@@ -60,12 +60,15 @@
   "Buffer local variable holding regexps from sql-mode to
 identify keywords.")
 
-(defvar last-sql-keyword "")
+(defvar last-sql-keyword nil
+  "Holds the last SQL keyword entered in the buffer.")
 
-(defvar in-execute-string nil)
+(defvar in-execute-string nil
+  "Set to t when we are in an eval string and not a regular string.")
 
 (defvar eval-keywords
-  '((postgres "EXECUTE")))
+  '((postgres "EXECUTE"))
+"List of keywords introducing eval strings, organised by dialect.")
 
 ;;;###autoload
 (define-minor-mode sqlup-mode


### PR DESCRIPTION
Allow upcasing SQL keywords inside strings that follow specific code-eval keywords, like "EXECUTE". These keywords are organised by dialect in an assoc list. For now, only EXECUTE is there (PostgreSQL), but others can be added easily.