### PR TITLE
Moved sqlup-in-execute-string back to a global variable

### DIFF
--- a/sqlup-mode.el
+++ b/sqlup-mode.el
@@ -91,7 +91,6 @@ this mode's logic will be evaluated.")
 (defun sqlup-enable-keyword-capitalization ()
   (set (make-local-variable 'sqlup-local-keywords) nil)
   (set (make-local-variable 'sqlup-last-sql-keyword) nil)
-  (set (make-local-variable 'sqlup-in-execute-string) nil)
   "Add buffer-local hook to handle this mode's logic"
   (add-hook 'post-command-hook 'sqlup-capitalize-as-you-type nil t))
 


### PR DESCRIPTION
Commit 910623e26 (Really make variables buffer-local) broke the eval of SQL in strings, as sqlup-in-execute-string in checked and flipped between t and nil in sqlup-capitalizable-p, which does its work within with-temp-buffer scope. From there, sqlup-in-execute-string cannot be reached AFAIK.

This fix just removes the line 
(set (make-local-variable 'sqlup-in-execute-string) nil)

This allows to get the eval in strings behaviour back, at the expense of putting the variable back in the global scope, which is not ideal. At the moment, I'm not sure how to write a proper fix maintaining the variable buffer-local.
