### PR TITLE
Feature no global evals

### DIFF
--- a/features/sqlup-mode.el.feature
+++ b/features/sqlup-mode.el.feature
@@ -21,3 +21,40 @@ Feature: Upcasing as I type
     And I insert "addslots"
     And I type " "
     Then I should see "ADDSLOTS "
+
+ Scenario: Upcase a normal SQL keyword in a postgres-execute eval string
+    Given I turn on sqlup-mode
+    And I start an action chain
+    And I press "M-x"
+    And I type "sql-highlight-postgres-keywords"
+    And I execute the action chain
+    And I insert "execute"
+    And I type " "
+    And I insert "'select"
+    And I type " "
+    Then I should see "EXECUTE 'SELECT "
+
+ Scenario: Upcase a normal SQL keyword in a postgres-format eval string
+    Given I turn on sqlup-mode
+    And I start an action chain
+    And I press "M-x"
+    And I type "sql-highlight-postgres-keywords"
+    And I execute the action chain
+    And I insert "execute"
+    And I type " "
+    And I insert "format("
+    And I insert "'select"
+    And I type " "
+    Then I should see "EXECUTE format('SELECT "
+
+ Scenario: Normal strings are never upcased
+    Given I turn on sqlup-mode
+    And I start an action chain
+    And I press "M-x"
+    And I type "sql-highlight-postgres-keywords"
+    And I execute the action chain
+    And I insert "select"
+    And I type " "
+    And I insert "'case"
+    And I type " "
+    Then I should see "SELECT 'case "


### PR DESCRIPTION
This implements upcasing for eval strings without relying on global variables.
The new implementation also works with multi-line eval strings.

I also added some test cases with ecukes. I could not find a way to check a multi-line string, though.

Note that the branch was derived from add-testing.