### PR TITLE
Add some tests for sql interactive mode

### DIFF
--- a/features/sql-interactive.feature
+++ b/features/sql-interactive.feature
@@ -1,0 +1,14 @@
+Feature: Upcasing SQL as I type in SQL interactive mode
+
+  Background:
+    Given the buffer is empty
+    And I mock turn on sql-interactive-mode
+    And I turn on sqlup-mode
+
+  Scenario: Upcase normal sql keywords
+    Given I type "select * from x"
+    Then I should see "SELECT * FROM x"
+
+  Scenario: keywords in strings and comments do not get upcased
+    Given I type "select count(*) 'select' -- select "
+    Then I should see "SELECT COUNT(*) 'select' -- select "

--- a/features/step-definitions/sqlup-mode.el-steps.el
+++ b/features/step-definitions/sqlup-mode.el-steps.el
@@ -39,3 +39,10 @@
   (lambda (mode)
     (let ((v (vconcat [?\C-u ?\M-x] (string-to-vector mode) [?\C-m])))
 (execute-kbd-macro v))))
+
+(When "^I mock turn on sql-interactive-mode$"
+      "Turn on sql-interactive mode with process interaction functions mocked out"
+      (lambda ()
+        (cl-letf (((symbol-function 'set-process-sentinel) #'ignore)
+                  ((symbol-function 'get-buffer-process) #'ignore))
+          (sql-interactive-mode))))

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -15,6 +15,7 @@
 (require 'espuds)
 (require 'sqlup-mode (f-expand "sqlup-mode.el" sqlup-mode-root-path))
 (require 'redis)
+(require 'cl-lib)
 
 (Setup
  ;; Before anything has run


### PR DESCRIPTION
I've made a simple mock for sql-interactive-mode that can be used without needing a real sql database backend. It uses [letf](http://endlessparentheses.com/understanding-letf-and-how-it-replaces-flet.html) to replace the functions that would normally interact with the database with no-ops.

The tests pass immediately, which is good :+1: 

P.S. I have this week off and I feel like doing some programming, so there may be a bit of a barrage of PRs coming, feel free to ignore them until you have some free time.