### PR TITLE
Fix postgres meta commands

### DIFF
--- a/features/postgres-sql.feature
+++ b/features/postgres-sql.feature
@@ -1,0 +1,19 @@
+Feature: Postgres product specific tweaks
+
+  Background:
+    Given the buffer is empty
+    And I turn on sql-mode
+    And I turn on sqlup-mode
+    And I use the sql product "postgres"
+
+ Scenario: Upcase a normal SQL keyword in a postgres-execute eval string
+    And I type "execute 'select "
+    Then I should see "EXECUTE 'SELECT "
+
+ Scenario: Upcase a normal SQL keyword in a postgres-format eval string
+    And I type "execute format('select "
+    Then I should see "EXECUTE format('SELECT "
+
+ Scenario: Normal strings are never upcased
+    And I type "select 'case "
+    Then I should see "SELECT 'case "

--- a/features/postgres-sql.feature
+++ b/features/postgres-sql.feature
@@ -17,3 +17,7 @@ Feature: Postgres product specific tweaks
  Scenario: Normal strings are never upcased
     And I type "select 'case "
     Then I should see "SELECT 'case "
+
+  Scenario: Postgres meta commands are not upcased
+    When I type "\c "
+    Then I should see "\c "

--- a/features/sql.feature
+++ b/features/sql.feature
@@ -29,21 +29,6 @@ Feature: Upcasing SQL as I type
     Given I type "select count(*) 'select' -- select "
     Then I should see "SELECT COUNT(*) 'select' -- select "
 
- Scenario: Upcase a normal SQL keyword in a postgres-execute eval string
-    When I use the sql product "postgres"
-    And I type "execute 'select "
-    Then I should see "EXECUTE 'SELECT "
-
- Scenario: Upcase a normal SQL keyword in a postgres-format eval string
-    When I use the sql product "postgres"
-    And I type "execute format('select "
-    Then I should see "EXECUTE format('SELECT "
-
- Scenario: Normal strings are never upcased
-    When I use the sql product "postgres"
-    And I type "select 'case "
-    Then I should see "SELECT 'case "
-
   Scenario: Normal strings with _ ending in a keyword are not upcased
     When I type "select peer_group "
     Then I should see "SELECT peer_group "

--- a/sqlup-mode.el
+++ b/sqlup-mode.el
@@ -129,9 +129,13 @@ Other than <RET>, characters are in variable sqlup-trigger-characters."
 
 (defun sqlup-maybe-capitalize-symbol (direction)
   "DIRECTION is either 1 for forward or -1 for backward"
-  (forward-symbol direction)
-  (sqlup-work-on-symbol (thing-at-point 'symbol)
-                        (bounds-of-thing-at-point 'symbol)))
+  (with-syntax-table (make-syntax-table sql-mode-syntax-table)
+    ;; Give \ symbol syntax so that it is included when we get a symbol. This is
+    ;; needed so that \c in postgres is not treated as the keyword C.
+    (modify-syntax-entry ?\\ "_")
+    (forward-symbol direction)
+    (sqlup-work-on-symbol (thing-at-point 'symbol)
+                          (bounds-of-thing-at-point 'symbol))))
 
 (defun sqlup-work-on-symbol (symbol symbol-boundaries)
   (if (and symbol


### PR DESCRIPTION
 Fix \c etc. in postgres being treated as C

Closes #38